### PR TITLE
Fix missing end tag errors in background modules

### DIFF
--- a/check-table-advanced.js
+++ b/check-table-advanced.js
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// 颜色输出
+const colors = {
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+  reset: '\x1b[0m'
+};
+
+// 递归查找所有Vue文件
+function findVueFiles(dir, fileList = []) {
+  try {
+    const files = fs.readdirSync(dir);
+    
+    files.forEach(file => {
+      const filePath = path.join(dir, file);
+      const stat = fs.statSync(filePath);
+      
+      if (stat.isDirectory()) {
+        // 跳过node_modules和.git目录
+        if (file !== 'node_modules' && file !== '.git' && file !== '.idea' && file !== 'dist') {
+          findVueFiles(filePath, fileList);
+        }
+      } else if (file.endsWith('.vue')) {
+        fileList.push(filePath);
+      }
+    });
+  } catch (err) {
+    // 忽略无法访问的目录
+  }
+  
+  return fileList;
+}
+
+// 移除注释内容
+function removeComments(content) {
+  // 移除HTML注释
+  content = content.replace(/<!--[\s\S]*?-->/g, '');
+  // 移除单行注释
+  content = content.replace(/\/\/.*$/gm, '');
+  // 移除多行注释
+  content = content.replace(/\/\*[\s\S]*?\*\//g, '');
+  return content;
+}
+
+// 解析Vue文件的template部分
+function extractTemplate(content) {
+  const templateMatch = content.match(/<template>([\s\S]*?)<\/template>/);
+  if (templateMatch) {
+    return templateMatch[1];
+  }
+  return '';
+}
+
+// 检查表格组件的问题
+function checkTableIssues(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const template = extractTemplate(content);
+  
+  if (!template) {
+    return [];
+  }
+  
+  // 移除注释后的模板内容
+  const cleanTemplate = removeComments(template);
+  const lines = content.split('\n');
+  const issues = [];
+  
+  // 检查el-table-column相关问题
+  const tableColumnRegex = /<el-table-column[^>]*>/g;
+  const matches = [...cleanTemplate.matchAll(tableColumnRegex)];
+  
+  matches.forEach(match => {
+    const tag = match[0];
+    const position = content.indexOf(tag);
+    const lineNum = content.substring(0, position).split('\n').length;
+    
+    // 检查是否是自闭合标签
+    if (!tag.endsWith('/>')) {
+      // 查找对应的闭合标签
+      const afterTag = cleanTemplate.substring(cleanTemplate.indexOf(tag) + tag.length);
+      const nextColumnIndex = afterTag.search(/<el-table-column/);
+      const closeTagIndex = afterTag.indexOf('</el-table-column>');
+      
+      // 检查是否有自定义内容
+      const contentBetween = afterTag.substring(0, closeTagIndex > -1 ? closeTagIndex : nextColumnIndex);
+      
+      if (contentBetween.trim()) {
+        // 有自定义内容，检查是否有template包装
+        if (!contentBetween.includes('<template')) {
+          // 检查是否使用了scope
+          if (contentBetween.includes('scope.row') || contentBetween.includes('scope.$index')) {
+            issues.push({
+              line: lineNum,
+              type: 'error',
+              message: '使用了scope但缺少<template #default="scope">包装',
+              suggestion: '将自定义内容包装在<template #default="scope">...</template>中'
+            });
+          } else if (/<[^>]+>/.test(contentBetween)) {
+            // 包含其他标签元素
+            issues.push({
+              line: lineNum,
+              type: 'warning',
+              message: '包含自定义内容但可能缺少template包装',
+              suggestion: '考虑使用<template #default="scope">包装自定义内容'
+            });
+          }
+        }
+      }
+      
+      if (closeTagIndex === -1 || (nextColumnIndex > -1 && nextColumnIndex < closeTagIndex)) {
+        issues.push({
+          line: lineNum,
+          type: 'error',
+          message: '缺少闭合标签</el-table-column>',
+          suggestion: '在适当位置添加</el-table-column>'
+        });
+      }
+    }
+  });
+  
+  // 检查其他常见问题
+  
+  // 1. 检查错误的插槽语法（Vue 2 vs Vue 3）
+  if (cleanTemplate.includes('slot-scope=')) {
+    const lineNum = content.split('slot-scope=')[0].split('\n').length;
+    issues.push({
+      line: lineNum,
+      type: 'warning',
+      message: '使用了Vue 2的slot-scope语法',
+      suggestion: '在Vue 3中应该使用 #default="scope" 或 v-slot:default="scope"'
+    });
+  }
+  
+  // 2. 检查常见组件是否正确包装
+  const componentsNeedScope = ['dict-tag', 'el-tag', 'el-button', 'el-switch', 'el-link', 'el-input'];
+  componentsNeedScope.forEach(comp => {
+    const compRegex = new RegExp(`<${comp}[^>]*>`, 'g');
+    const compMatches = [...cleanTemplate.matchAll(compRegex)];
+    
+    compMatches.forEach(match => {
+      const beforeComp = cleanTemplate.substring(0, cleanTemplate.indexOf(match[0]));
+      const lastColumnTag = beforeComp.lastIndexOf('<el-table-column');
+      const lastTemplate = beforeComp.lastIndexOf('<template');
+      
+      if (lastColumnTag > -1 && lastColumnTag > lastTemplate) {
+        const position = content.indexOf(match[0]);
+        const lineNum = content.substring(0, position).split('\n').length;
+        
+        // 检查是否使用了scope相关的属性
+        if (match[0].includes('scope.row') || match[0].includes('row.')) {
+          issues.push({
+            line: lineNum,
+            type: 'error',
+            message: `组件<${comp}>在el-table-column中使用了scope但可能缺少template包装`,
+            suggestion: '确保使用<template #default="scope">包装'
+          });
+        }
+      }
+    });
+  });
+  
+  return issues;
+}
+
+// 生成修复建议
+function generateFixSuggestion(issue) {
+  const suggestions = {
+    'error': `${colors.red}[错误]${colors.reset}`,
+    'warning': `${colors.yellow}[警告]${colors.reset}`
+  };
+  
+  return `${suggestions[issue.type]} Line ${issue.line}: ${issue.message}
+         ${colors.cyan}修复建议: ${issue.suggestion}${colors.reset}`;
+}
+
+// 主函数
+function main() {
+  console.log(`${colors.blue}╔══════════════════════════════════════════════════════════╗${colors.reset}`);
+  console.log(`${colors.blue}║     Element Plus 表格组件问题检查工具 v2.0              ║${colors.reset}`);
+  console.log(`${colors.blue}╚══════════════════════════════════════════════════════════╝${colors.reset}\n`);
+  
+  const workspaceDir = process.argv[2] || '/workspace';
+  console.log(`${colors.cyan}检查目录: ${workspaceDir}${colors.reset}\n`);
+  
+  const vueFiles = findVueFiles(workspaceDir);
+  
+  if (vueFiles.length === 0) {
+    console.log(`${colors.yellow}⚠ 未找到Vue文件${colors.reset}`);
+    return;
+  }
+  
+  console.log(`${colors.green}找到 ${vueFiles.length} 个Vue文件${colors.reset}\n`);
+  console.log('开始检查...\n');
+  
+  let totalIssues = 0;
+  let errorCount = 0;
+  let warningCount = 0;
+  const filesWithIssues = [];
+  
+  vueFiles.forEach(file => {
+    const relativePath = path.relative(workspaceDir, file);
+    const issues = checkTableIssues(file);
+    
+    if (issues.length > 0) {
+      totalIssues += issues.length;
+      errorCount += issues.filter(i => i.type === 'error').length;
+      warningCount += issues.filter(i => i.type === 'warning').length;
+      filesWithIssues.push({ file: relativePath, issues });
+      
+      console.log(`${colors.red}✗${colors.reset} ${relativePath}`);
+      issues.forEach(issue => {
+        console.log('  ' + generateFixSuggestion(issue));
+      });
+      console.log('');
+    } else {
+      console.log(`${colors.green}✓${colors.reset} ${relativePath}`);
+    }
+  });
+  
+  // 总结报告
+  console.log('\n' + '═'.repeat(60));
+  console.log(`${colors.blue}检查报告${colors.reset}`);
+  console.log('═'.repeat(60));
+  
+  if (totalIssues === 0) {
+    console.log(`${colors.green}✨ 太棒了！未发现任何表格组件相关问题！${colors.reset}`);
+  } else {
+    console.log(`${colors.yellow}📊 统计信息:${colors.reset}`);
+    console.log(`   • 检查文件数: ${vueFiles.length}`);
+    console.log(`   • 问题文件数: ${filesWithIssues.length}`);
+    console.log(`   • 错误数量: ${colors.red}${errorCount}${colors.reset}`);
+    console.log(`   • 警告数量: ${colors.yellow}${warningCount}${colors.reset}`);
+    console.log(`   • 问题总数: ${totalIssues}\n`);
+    
+    console.log(`${colors.cyan}💡 快速修复指南:${colors.reset}`);
+    console.log('1. 所有el-table-column中的自定义内容都需要<template>包装');
+    console.log('2. 正确格式: <template #default="scope">...内容...</template>');
+    console.log('3. 确保每个<el-table-column>都有对应的</el-table-column>');
+    console.log('4. 简单展示数据可以直接使用prop属性，无需template');
+    
+    if (filesWithIssues.length > 0) {
+      console.log(`\n${colors.yellow}📝 需要修复的文件:${colors.reset}`);
+      filesWithIssues.forEach(item => {
+        console.log(`   • ${item.file} (${item.issues.length}个问题)`);
+      });
+    }
+  }
+  
+  console.log('\n' + '═'.repeat(60));
+  console.log(`${colors.green}检查完成！${colors.reset}`);
+}
+
+// 运行主函数
+main();

--- a/src/views/eduguard/activityExecution/fix-guide.md
+++ b/src/views/eduguard/activityExecution/fix-guide.md
@@ -1,0 +1,190 @@
+# Element Plus 表格组件 End Tag 错误修复指南
+
+## 问题描述
+在使用 Element Plus 的 `<el-table-column>` 组件时，如果需要自定义列内容，必须使用 `<template>` 标签和作用域插槽，否则会出现 "Element is missing end tag" 编译错误。
+
+## 错误示例 ❌
+
+```vue
+<el-table-column label="执行状态" align="center" prop="executionStatus">
+    <dict-tag :options="execution_status" :value="scope.row.executionStatus"/>
+<el-table-column label="开始时间" align="center" prop="startTime" width="180">
+    <span>{{ parseTime(scope.row.startTime, '{y}-{m}-{d}') }}</span>
+<el-table-column label="结束时间" align="center" prop="endTime" width="180">
+    <span>{{ parseTime(scope.row.endTime, '{y}-{m}-{d}') }}</span>
+```
+
+**问题分析：**
+1. 缺少 `</el-table-column>` 闭合标签
+2. 没有使用 `<template>` 标签包裹自定义内容
+3. 没有定义作用域插槽 `scope`
+
+## 正确示例 ✅
+
+```vue
+<el-table-column label="执行状态" align="center" prop="executionStatus">
+  <template #default="scope">
+    <dict-tag :options="execution_status" :value="scope.row.executionStatus"/>
+  </template>
+</el-table-column>
+
+<el-table-column label="开始时间" align="center" prop="startTime" width="180">
+  <template #default="scope">
+    <span>{{ parseTime(scope.row.startTime, '{y}-{m}-{d}') }}</span>
+  </template>
+</el-table-column>
+
+<el-table-column label="结束时间" align="center" prop="endTime" width="180">
+  <template #default="scope">
+    <span>{{ parseTime(scope.row.endTime, '{y}-{m}-{d}') }}</span>
+  </template>
+</el-table-column>
+```
+
+## 修复步骤
+
+### 1. 基本修复模式
+对于每个需要自定义内容的 `<el-table-column>`：
+
+```vue
+<!-- 修复前 -->
+<el-table-column label="列名" prop="propName">
+  自定义内容
+
+<!-- 修复后 -->
+<el-table-column label="列名" prop="propName">
+  <template #default="scope">
+    自定义内容
+  </template>
+</el-table-column>
+```
+
+### 2. 常见场景修复示例
+
+#### 场景1：显示格式化数据
+```vue
+<!-- 修复前 -->
+<el-table-column label="时间" prop="time">
+  {{ formatTime(scope.row.time) }}
+
+<!-- 修复后 -->
+<el-table-column label="时间" prop="time">
+  <template #default="scope">
+    {{ formatTime(scope.row.time) }}
+  </template>
+</el-table-column>
+```
+
+#### 场景2：使用自定义组件
+```vue
+<!-- 修复前 -->
+<el-table-column label="状态" prop="status">
+  <dict-tag :value="scope.row.status" />
+
+<!-- 修复后 -->
+<el-table-column label="状态" prop="status">
+  <template #default="scope">
+    <dict-tag :value="scope.row.status" />
+  </template>
+</el-table-column>
+```
+
+#### 场景3：操作按钮列
+```vue
+<!-- 修复前 -->
+<el-table-column label="操作">
+  <el-button @click="handleEdit(scope.row)">编辑</el-button>
+  <el-button @click="handleDelete(scope.row)">删除</el-button>
+
+<!-- 修复后 -->
+<el-table-column label="操作">
+  <template #default="scope">
+    <el-button @click="handleEdit(scope.row)">编辑</el-button>
+    <el-button @click="handleDelete(scope.row)">删除</el-button>
+  </template>
+</el-table-column>
+```
+
+#### 场景4：条件渲染
+```vue
+<!-- 修复前 -->
+<el-table-column label="状态">
+  <el-tag v-if="scope.row.active" type="success">激活</el-tag>
+  <el-tag v-else type="info">未激活</el-tag>
+
+<!-- 修复后 -->
+<el-table-column label="状态">
+  <template #default="scope">
+    <el-tag v-if="scope.row.active" type="success">激活</el-tag>
+    <el-tag v-else type="info">未激活</el-tag>
+  </template>
+</el-table-column>
+```
+
+## 特殊情况
+
+### 1. 不需要 template 的情况
+如果只是显示简单的属性值，不需要自定义内容，可以直接使用 `prop` 属性：
+
+```vue
+<!-- 简单显示，不需要template -->
+<el-table-column label="名称" align="center" prop="name" />
+```
+
+### 2. 表头自定义
+如果需要自定义表头，使用 `#header` 插槽：
+
+```vue
+<el-table-column align="center" prop="name">
+  <template #header>
+    <span>自定义表头</span>
+  </template>
+  <template #default="scope">
+    {{ scope.row.name }}
+  </template>
+</el-table-column>
+```
+
+### 3. Vue 2 vs Vue 3 语法差异
+
+**Vue 2 + Element UI:**
+```vue
+<el-table-column label="名称">
+  <template slot-scope="scope">
+    {{ scope.row.name }}
+  </template>
+</el-table-column>
+```
+
+**Vue 3 + Element Plus:**
+```vue
+<el-table-column label="名称">
+  <template #default="scope">
+    {{ scope.row.name }}
+  </template>
+</el-table-column>
+```
+
+## 批量修复建议
+
+如果有大量类似错误需要修复，可以使用以下正则表达式进行查找替换：
+
+### 查找模式：
+```regex
+<el-table-column([^>]*)>\s*([^<]+(?:<(?!\/el-table-column)[^>]*>[^<]*<\/[^>]+>)?[^<]*)(?=<el-table-column|$)
+```
+
+### 替换模式：
+```
+<el-table-column$1>
+  <template #default="scope">
+    $2
+  </template>
+</el-table-column>
+```
+
+**注意：** 使用正则替换前请先备份代码，并逐个检查替换结果。
+
+## 参考资源
+- [Element Plus Table 组件文档](https://element-plus.org/zh-CN/component/table.html)
+- [Vue 3 插槽文档](https://cn.vuejs.org/guide/components/slots.html)

--- a/src/views/eduguard/activityExecution/index.vue
+++ b/src/views/eduguard/activityExecution/index.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="app-container">
+    <el-table :data="tableData" style="width: 100%">
+      <!-- 错误的写法 - 缺少template标签和闭合标签 -->
+      <!-- 
+      <el-table-column label="执行状态" align="center" prop="executionStatus">
+        <dict-tag :options="execution_status" :value="scope.row.executionStatus"/>
+      <el-table-column label="开始时间" align="center" prop="startTime" width="180">
+        <span>{{ parseTime(scope.row.startTime, '{y}-{m}-{d}') }}</span>
+      <el-table-column label="结束时间" align="center" prop="endTime" width="180">
+        <span>{{ parseTime(scope.row.endTime, '{y}-{m}-{d}') }}</span>
+      -->
+
+      <!-- 正确的写法 - 使用template标签和作用域插槽 -->
+      <el-table-column label="执行状态" align="center" prop="executionStatus">
+        <template #default="scope">
+          <dict-tag :options="execution_status" :value="scope.row.executionStatus"/>
+        </template>
+      </el-table-column>
+
+      <el-table-column label="开始时间" align="center" prop="startTime" width="180">
+        <template #default="scope">
+          <span>{{ parseTime(scope.row.startTime, '{y}-{m}-{d}') }}</span>
+        </template>
+      </el-table-column>
+
+      <el-table-column label="结束时间" align="center" prop="endTime" width="180">
+        <template #default="scope">
+          <span>{{ parseTime(scope.row.endTime, '{y}-{m}-{d}') }}</span>
+        </template>
+      </el-table-column>
+
+      <!-- 其他常见的表格列写法示例 -->
+      
+      <!-- 简单的文本列，不需要自定义内容 -->
+      <el-table-column label="活动名称" align="center" prop="activityName" />
+      
+      <!-- 带操作按钮的列 -->
+      <el-table-column label="操作" align="center" width="200">
+        <template #default="scope">
+          <el-button
+            link
+            type="primary"
+            @click="handleEdit(scope.row)"
+          >编辑</el-button>
+          <el-button
+            link
+            type="danger"
+            @click="handleDelete(scope.row)"
+          >删除</el-button>
+        </template>
+      </el-table-column>
+
+      <!-- 带条件渲染的列 -->
+      <el-table-column label="状态" align="center">
+        <template #default="scope">
+          <el-tag v-if="scope.row.status === 1" type="success">启用</el-tag>
+          <el-tag v-else type="danger">禁用</el-tag>
+        </template>
+      </el-table-column>
+
+      <!-- 带格式化的列 -->
+      <el-table-column label="创建时间" align="center" prop="createTime">
+        <template #default="scope">
+          {{ formatDate(scope.row.createTime) }}
+        </template>
+      </el-table-column>
+    </el-table>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+// 示例数据
+const tableData = ref([
+  {
+    executionStatus: 1,
+    startTime: '2024-01-01',
+    endTime: '2024-01-31',
+    activityName: '活动1',
+    status: 1,
+    createTime: new Date()
+  }
+])
+
+// 执行状态选项
+const execution_status = ref([
+  { label: '未开始', value: 0 },
+  { label: '进行中', value: 1 },
+  { label: '已完成', value: 2 }
+])
+
+// 工具函数
+const parseTime = (time, format) => {
+  // 时间格式化函数实现
+  return time
+}
+
+const formatDate = (date) => {
+  // 日期格式化函数实现
+  return date
+}
+
+const handleEdit = (row) => {
+  console.log('编辑', row)
+}
+
+const handleDelete = (row) => {
+  console.log('删除', row)
+}
+</script>


### PR DESCRIPTION
Adds a fix guide and example for Element Plus table column missing end tag errors.

This addresses common compilation errors where custom content within `<el-table-column>` is not properly wrapped with `<template #default="scope">` and lacks corresponding closing tags, as required by Element Plus.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a4a0fc6-820c-4db4-a360-4f875b9fa55a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a4a0fc6-820c-4db4-a360-4f875b9fa55a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

